### PR TITLE
add highlights config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ require 'triptych'.setup {
       fallback_file_icon = ''
     },
     column_widths = { .25, .25, .5 }, -- Must add up to 1 after rounding to 2 decimal places
+    highlights = { -- Highlight groups to use. See `:highlight` or `:h highlight`
+      file_names = 'NONE',
+      directory_names = 'NONE',
+    },
   },
   git_signs = {
     enabled = true,

--- a/lua/spec/config_spec.lua
+++ b/lua/spec/config_spec.lua
@@ -32,6 +32,10 @@ local function expected_default_config()
         fallback_file_icon = '',
       },
       column_widths = { 0.25, 0.25, 0.5 },
+      highlights = {
+        file_names = 'NONE',
+        directory_names = 'NONE',
+      },
     },
     git_signs = {
       enabled = true,

--- a/lua/spec/float_spec.lua
+++ b/lua/spec/float_spec.lua
@@ -381,14 +381,32 @@ describe('buf_apply_highlights', function()
       },
     }
     float.buf_apply_highlights(4, {
-      { highlight_name = 'hello', char_count = 3 },
-      { highlight_name = 'world', char_count = 3 },
-      { highlight_name = 'monkey', char_count = 3 },
+      {
+        icon = {
+          highlight_name = 'icon_hl',
+          length = 5,
+        },
+        text = {
+          highlight_name = 'text_hl',
+          starts = 2,
+        },
+      },
+      {
+        icon = {
+          highlight_name = 'icon_hl_2',
+          length = 4,
+        },
+        text = {
+          highlight_name = 'text_hl_2',
+          starts = 1,
+        },
+      },
     })
     assert.same({
-      { 4, 0, 'hello', 0, 0, 3 },
-      { 4, 0, 'world', 1, 0, 3 },
-      { 4, 0, 'monkey', 2, 0, 3 },
+      { 4, 0, 'icon_hl', 0, 0, 5 },
+      { 4, 0, 'text_hl', 0, 2, -1 },
+      { 4, 0, 'icon_hl_2', 1, 0, 4 },
+      { 4, 0, 'text_hl_2', 1, 1, -1 },
     }, nvim_buf_add_highlight_spy)
   end)
 end)

--- a/lua/spec/view_spec.lua
+++ b/lua/spec/view_spec.lua
@@ -230,9 +230,9 @@ describe('update_child_window', function()
       {
         11,
         {
-          { highlight_name = 'Directory', char_count = 3 },
-          { highlight_name = 'Comment', char_count = 1 },
-          { highlight_name = 'Comment', char_count = 1 },
+          { icon = { highlight_name = 'Directory', length = 3 }, text = { highlight_name = 'NONE', starts = 3 } },
+          { icon = { highlight_name = 'Comment', length = 3 }, text = { highlight_name = 'NONE', starts = 3 } },
+          { icon = { highlight_name = 'Comment', length = 3 }, text = { highlight_name = 'NONE', starts = 3 } },
         },
       },
     }, spies.float.buf_apply_highlights)
@@ -460,8 +460,28 @@ describe('nav_to', function()
       { 1, 'level_3', '', 'Directory' },
     }, spies.float.win_set_title)
     assert.same({
-      { 7, { { highlight_name = 'Comment', char_count = 1 } } },
-      { 8, { { highlight_name = 'Directory', char_count = 3 }, { highlight_name = 'Comment', char_count = 1 } } },
+      {
+        7,
+        {
+          {
+            icon = { highlight_name = 'Comment', length = 3 },
+            text = { highlight_name = 'NONE', starts = 3 },
+          },
+        },
+      },
+      {
+        8,
+        {
+          {
+            icon = { highlight_name = 'Directory', length = 3 },
+            text = { highlight_name = 'NONE', starts = 3 },
+          },
+          {
+            icon = { highlight_name = 'Comment', length = 3 },
+            text = { highlight_name = 'NONE', starts = 3 },
+          },
+        },
+      },
     }, spies.float.buf_apply_highlights)
     assert.same({ 7 }, spies.vim.api.nvim_buf_line_count)
     assert.same({

--- a/lua/triptych/config.lua
+++ b/lua/triptych/config.lua
@@ -32,6 +32,10 @@ local function default_config()
         fallback_file_icon = '',
       },
       column_widths = { 0.25, 0.25, 0.5 },
+      highlights = {
+        file_names = 'NONE',
+        directory_names = 'NONE',
+      },
     },
     git_signs = {
       enabled = true,

--- a/lua/triptych/float.lua
+++ b/lua/triptych/float.lua
@@ -25,13 +25,15 @@ local function buf_set_lines(buf, lines)
 end
 
 ---@param buf number
----@param highlights { highlight_name: string, char_count: number }[]
+---@param highlights HighlightDetails[]
 ---@return nil
 local function buf_apply_highlights(buf, highlights)
   local vim = _G.triptych_mock_vim or vim
+  -- Apply icon highlight
   for i, highlight in ipairs(highlights) do
-    -- Col end is hard-coded to to 3 because this is only used to for the filetype icons
-    vim.api.nvim_buf_add_highlight(buf, 0, highlight.highlight_name, i - 1, 0, highlight.char_count)
+    vim.api.nvim_buf_add_highlight(buf, 0, highlight.icon.highlight_name, i - 1, 0, highlight.icon.length)
+    -- Apply file or directory highlight
+    vim.api.nvim_buf_add_highlight(buf, 0, highlight.text.highlight_name, i - 1, highlight.text.starts, -1)
   end
 end
 

--- a/lua/triptych/types.lua
+++ b/lua/triptych/types.lua
@@ -48,6 +48,11 @@
 ---@field line_numbers TriptychConfigLineNumbers
 ---@field file_icons TriptychConfigFileIcons
 ---@field column_widths number[]
+---@field highlights TriptychConfigHighlights
+
+---@class TriptychConfigHighlights
+---@field file_names string
+---@field directory_names string
 
 ---@class TriptychConfigLineNumbers
 ---@field enabled boolean
@@ -118,6 +123,18 @@
 ---@field enable_cursorline boolean
 ---@field show_numbers boolean
 ---@field relative_numbers boolean
+
+---@class HighlightDetails
+---@field icon HighlightDetailsIcon
+---@field text HighlightDetailsText
+
+---@class HighlightDetailsIcon
+---@field highlight_name string
+---@field length number
+
+---@class HighlightDetailsText
+---@field highlight_name string
+---@field starts number
 
 ---@class Diagnostics
 ---@field new fun(): Diagnostics

--- a/lua/triptych/view.lua
+++ b/lua/triptych/view.lua
@@ -47,32 +47,70 @@ end
 ---@param State TriptychState
 ---@param path_details PathDetails
 ---@return string[] # Lines including icons
----@return { highlight_name: string, char_count: number }[] # Highlights for icons
+---@return HighlightDetails[]
 local function path_details_to_lines(State, path_details)
   local vim = _G.triptych_mock_vim or vim
-  local icons_config = vim.g.triptych_config.options.file_icons
+  local config_options = vim.g.triptych_config.options
+  local icons_enabled = config_options.file_icons.enabled
   local lines = {}
   local highlights = {}
 
   for _, child in ipairs(path_details.children) do
     local line, highlight_name = u.cond(child.is_dir, {
       when_true = function()
-        if icons_config.enabled then
-          local line = icons_config.directory_icon .. ' ' .. child.display_name
-          return line, { highlight_name = 'Directory', char_count = string.len(icons_config.directory_icon) }
-        end
-        return child.display_name
+        local icon_length = string.len(config_options.file_icons.directory_icon)
+        local highlight = {
+          icon = {
+            highlight_name = 'Directory',
+            length = u.cond(icons_enabled, {
+              when_true = icon_length,
+              when_false = 0,
+            }),
+          },
+          text = {
+            highlight_name = config_options.highlights.directory_names,
+            starts = u.cond(icons_enabled, {
+              when_true = icon_length,
+              when_false = 0,
+            }),
+          },
+        }
+        local line = u.cond(icons_enabled, {
+          when_true = config_options.file_icons.directory_icon .. ' ' .. child.display_name,
+          when_false = child.display_name,
+        })
+        return line, highlight
       end,
       when_false = function()
-        if icons_config.enabled then
+        local icon, icon_highlight = u.eval(function()
           local maybe_icon, maybe_highlight = icons.get_icon_by_filetype(child.filetype)
           local highlight = maybe_highlight or 'Comment'
-          local fallback_icon = icons_config.fallback_file_icon
+          local fallback_icon = config_options.file_icons.fallback_file_icon
           local icon = maybe_icon or fallback_icon
-          local line = icon .. ' ' .. child.display_name
-          return line, { highlight_name = highlight, char_count = string.len(icon) }
-        end
-        return child.display_name
+          return icon, highlight
+        end)
+        local icon_length = string.len(config_options.file_icons.fallback_file_icon)
+        local highlight = {
+          icon = {
+            highlight_name = icon_highlight,
+            length = u.cond(icons_enabled, {
+              when_true = icon_length,
+              when_false = 0,
+            }),
+          },
+          text = {
+            highlight_name = config_options.highlights.file_names,
+            starts = u.cond(icons_enabled, {
+              when_true = icon_length,
+              when_false = 0,
+            }),
+          },
+        }
+        local line = u.cond(icons_enabled, {
+          when_true = icon .. ' ' .. child.display_name,
+          when_false = child.display_name,
+        })
+        return line, highlight
       end,
     })
 


### PR DESCRIPTION
Allows the user to apply highlight groups to file and directory names. Requested in issue #8 