### PR TITLE
Fix (#31): Enhance config options for git sign highlighting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ require 'triptych'.setup {
   git_signs = {
     enabled = true,
     signs = {
+      -- The value can be either a string or a table.
+      -- If a string, will be basic text. If a table, will be passed as the {dict} argument to vim.fn.sign_define
+      -- If you want to add color, you can specify a highlight group in the table.
       add = '+',
       modify = '~',
       rename = 'r',

--- a/lua/triptych/config.lua
+++ b/lua/triptych/config.lua
@@ -49,12 +49,6 @@ local function default_config()
         rename = 'r',
         untracked = '?',
       },
-      colors = {
-        add = { fg = '#98c379' },
-        modify = { fg = '#e5c07b' },
-        rename = { fg = '#61afef' },
-        untracked = { fg = '#e06c75' },
-      },
     },
     diagnostic_signs = {
       enabled = true,

--- a/lua/triptych/config.lua
+++ b/lua/triptych/config.lua
@@ -49,6 +49,12 @@ local function default_config()
         rename = 'r',
         untracked = '?',
       },
+      colors = {
+        add = { fg = '#98c379' },
+        modify = { fg = '#e5c07b' },
+        rename = { fg = '#61afef' },
+        untracked = { fg = '#e06c75' },
+      },
     },
     diagnostic_signs = {
       enabled = true,

--- a/lua/triptych/git.lua
+++ b/lua/triptych/git.lua
@@ -27,13 +27,13 @@ function Git.new()
   local git_status = u.multiline_str_to_table(vim.fn.system 'git status --porcelain')
   local result = {}
 
-  local signs_config = vim.g.triptych_config.git_signs
+  local signs_config = vim.g.triptych_config.git_signs.signs
 
   local signs_to_text = {
-    ['TriptychGitAdd'] = signs_config.signs.add,
-    ['TriptychGitModify'] = signs_config.signs.modify,
-    ['TriptychGitRename'] = signs_config.signs.rename,
-    ['TriptychGitUntracked'] = signs_config.signs.untracked,
+    ['TriptychGitAdd'] = signs_config.add,
+    ['TriptychGitModify'] = signs_config.modify,
+    ['TriptychGitRename'] = signs_config.rename,
+    ['TriptychGitUntracked'] = signs_config.untracked,
   }
 
   -- Register the signs if they're not already

--- a/lua/triptych/git.lua
+++ b/lua/triptych/git.lua
@@ -30,33 +30,20 @@ function Git.new()
   local signs_config = vim.g.triptych_config.git_signs
 
   local signs_to_text = {
-    ['TriptychGitAdd'] = {
-      text = signs_config.signs.add,
-      texthl = 'TriptychSignGitAdd',
-      hl = signs_config.colors.add,
-    },
-    ['TriptychGitModify'] = {
-      text = signs_config.signs.modify,
-      texthl = 'TriptychSignGitModify',
-      hl = signs_config.colors.modify,
-    },
-    ['TriptychGitRename'] = {
-      text = signs_config.signs.rename,
-      texthl = 'TriptychSignGitRename',
-      hl = signs_config.colors.rename,
-    },
-    ['TriptychGitUntracked'] = {
-      text = signs_config.signs.untracked,
-      texthl = 'TriptychSignGitUntracked',
-      hl = signs_config.colors.untracked,
-    },
+    ['TriptychGitAdd'] = signs_config.signs.add,
+    ['TriptychGitModify'] = signs_config.signs.modify,
+    ['TriptychGitRename'] = signs_config.signs.rename,
+    ['TriptychGitUntracked'] = signs_config.signs.untracked,
   }
 
   -- Register the signs if they're not already
   for sign_name, opts in pairs(signs_to_text) do
     if u.is_empty(vim.fn.sign_getdefined(sign_name)) then
-      vim.fn.sign_define(sign_name, { text = opts.text, texthl = opts.texthl })
-      vim.api.nvim_set_hl(0, opts.texthl, opts.hl)
+      if type(opts) == 'string' then
+        vim.fn.sign_define(sign_name, { text = opts })
+      elseif type(opts) == 'table' then
+        vim.fn.sign_define(sign_name, opts)
+      end
     end
   end
 

--- a/lua/triptych/git.lua
+++ b/lua/triptych/git.lua
@@ -27,19 +27,36 @@ function Git.new()
   local git_status = u.multiline_str_to_table(vim.fn.system 'git status --porcelain')
   local result = {}
 
-  local signs_config = vim.g.triptych_config.git_signs.signs
+  local signs_config = vim.g.triptych_config.git_signs
 
   local signs_to_text = {
-    ['TriptychGitAdd'] = signs_config.add,
-    ['TriptychGitModify'] = signs_config.modify,
-    ['TriptychGitRename'] = signs_config.rename,
-    ['TriptychGitUntracked'] = signs_config.untracked,
+    ['TriptychGitAdd'] = {
+      text = signs_config.signs.add,
+      texthl = 'TriptychSignGitAdd',
+      hl = signs_config.colors.add,
+    },
+    ['TriptychGitModify'] = {
+      text = signs_config.signs.modify,
+      texthl = 'TriptychSignGitModify',
+      hl = signs_config.colors.modify,
+    },
+    ['TriptychGitRename'] = {
+      text = signs_config.signs.rename,
+      texthl = 'TriptychSignGitRename',
+      hl = signs_config.colors.rename,
+    },
+    ['TriptychGitUntracked'] = {
+      text = signs_config.signs.untracked,
+      texthl = 'TriptychSignGitUntracked',
+      hl = signs_config.colors.untracked,
+    },
   }
 
   -- Register the signs if they're not already
-  for sign_name, text in pairs(signs_to_text) do
+  for sign_name, opts in pairs(signs_to_text) do
     if u.is_empty(vim.fn.sign_getdefined(sign_name)) then
-      vim.fn.sign_define(sign_name, { text = text })
+      vim.fn.sign_define(sign_name, { text = opts.text, texthl = opts.texthl })
+      vim.api.nvim_set_hl(0, opts.texthl, opts.hl)
     end
   end
 

--- a/lua/triptych/types.lua
+++ b/lua/triptych/types.lua
@@ -71,12 +71,23 @@
 ---@class TriptychConfigGitSigns
 ---@field enabled boolean
 ---@field signs TriptychConfigGitSignsSigns
+---@field colors TriptychConfigGitSignsColors
 
 ---@class TriptychConfigGitSignsSigns
 ---@field add string
 ---@field modify string
 ---@field rename string
 ---@field untracked string
+
+---@class TriptychConfigGitSignsColors
+---@field add TriptychNvimHLParams
+---@field modify TriptychNvimHLParams
+---@field rename TriptychNvimHLParams
+---@field untracked TriptychNvimHLParams
+
+---@class TriptychNvimHLParams
+---@field fg string
+---@field bg string
 
 ---@class TriptychConfigDiagnostic
 ---@field enabled boolean

--- a/lua/triptych/types.lua
+++ b/lua/triptych/types.lua
@@ -71,23 +71,20 @@
 ---@class TriptychConfigGitSigns
 ---@field enabled boolean
 ---@field signs TriptychConfigGitSignsSigns
----@field colors TriptychConfigGitSignsColors
 
 ---@class TriptychConfigGitSignsSigns
----@field add string
----@field modify string
----@field rename string
----@field untracked string
+---@field add string | TriptychConfigGitSignDefineOptions
+---@field modify string | TriptychConfigGitSignDefineOptions
+---@field rename string | TriptychConfigGitSignDefineOptions
+---@field untracked string | TriptychConfigGitSignDefineOptions
 
----@class TriptychConfigGitSignsColors
----@field add TriptychNvimHLParams
----@field modify TriptychNvimHLParams
----@field rename TriptychNvimHLParams
----@field untracked TriptychNvimHLParams
-
----@class TriptychNvimHLParams
----@field fg string
----@field bg string
+---@class TriptychConfigGitSignDefineOptions
+---@field icon? string
+---@field linehl? string
+---@field numhl? string
+---@field text? string
+---@field texthl? string
+---@field culhl? string
 
 ---@class TriptychConfigDiagnostic
 ---@field enabled boolean

--- a/validate.sh
+++ b/validate.sh
@@ -24,6 +24,14 @@ fi
 
 echo "Checking formatting..."
 npx @johnnymorganz/stylua-bin --check .
+formatting_exit_code=$?
+
+if [ $formatting_exit_code -ne 0 ]; then
+  echo "❌ 1 or more files are not formatted correctly. Formatting...";
+  stylua --config-path stylua.toml --respect-ignores ./
+else
+  echo "✅ All files are formatted correctly";
+fi
 
 echo "Check diagnostics..."
 ~/.local/share/nvim/mason/bin/lua-language-server --check .


### PR DESCRIPTION
Addresses issue #31 by adding more fine-grained control over the file git signs and their highlight groups. Users can specify their signs as either a string or a table, with the table passed to the `vim.fn.sign_define` function. The type for the table-type config was created, and the `TriptychConfigGitSigns` type was updated to use either definition.

(Side note: I also updated `validate.sh` because it was notifying about format errors, but not actually doing anything about it.)