### PR TITLE
Fixed issue when invoking from a terminal window (#37)

### DIFF
--- a/lua/triptych/init.lua
+++ b/lua/triptych/init.lua
@@ -36,18 +36,18 @@ local function toggle_triptych(dir)
   local FileReader = file_reader.new(config.options.syntax_highlighting.debounce_ms)
 
   local opening_dir, selected_file = u.eval(function()
-      if dir then
-        -- if dir is given, open it
-        return dir, nil
-      elseif vim.api.nvim_buf_get_option(0, 'buftype') == 'terminal' then
-        -- in case of a terminal buffer, open the current working directory
-        return vim.fn.getcwd(), nil
-      else
-        -- otherwise open the directory containing the current file and select it
-        local path = vim.api.nvim_buf_get_name(0)
-        return vim.fs.dirname(path), path
-      end
-    end)
+    if dir then
+      -- if dir is given, open it
+      return dir, nil
+    elseif vim.api.nvim_buf_get_option(0, 'buftype') == 'terminal' then
+      -- in case of a terminal buffer, open the current working directory
+      return vim.fn.getcwd(), nil
+    else
+      -- otherwise open the directory containing the current file and select it
+      local path = vim.api.nvim_buf_get_name(0)
+      return vim.fs.dirname(path), path
+    end
+  end)
 
   local windows = float.create_three_floating_windows(
     config.options.line_numbers.enabled,

--- a/lua/triptych/init.lua
+++ b/lua/triptych/init.lua
@@ -35,15 +35,20 @@ local function toggle_triptych(dir)
   local Diagnostics = config.diagnostic_signs.enabled and diagnostics.new() or nil
   local FileReader = file_reader.new(config.options.syntax_highlighting.debounce_ms)
 
-  local maybe_buf_name = u.cond(dir, {
-    when_true = nil,
-    when_false = vim.api.nvim_buf_get_name(0),
-  })
-  local opening_dir = dir
-    or u.cond(u.is_defined(maybe_buf_name), {
-      when_true = vim.fs.dirname(maybe_buf_name),
-      when_false = vim.fn.getcwd(),
-    })
+  local opening_dir, selected_file = u.eval(function()
+      if dir then
+        -- if dir is given, open it
+        return dir, nil
+      elseif vim.api.nvim_buf_get_option(0, 'buftype') == 'terminal' then
+        -- in case of a terminal buffer, open the current working directory
+        return vim.fn.getcwd(), nil
+      else
+        -- otherwise open the directory containing the current file and select it
+        local path = vim.api.nvim_buf_get_name(0)
+        return vim.fs.dirname(path), path
+      end
+    end)
+
   local windows = float.create_three_floating_windows(
     config.options.line_numbers.enabled,
     config.options.line_numbers.relative,
@@ -88,7 +93,7 @@ local function toggle_triptych(dir)
     FileReader:destroy()
   end
 
-  view.nav_to(State, opening_dir, Diagnostics, Git, maybe_buf_name)
+  view.nav_to(State, opening_dir, Diagnostics, Git, selected_file)
 
   vim.g.triptych_is_open = true
   vim.g.triptych_close = close

--- a/unit_tests/init_spec.lua
+++ b/unit_tests/init_spec.lua
@@ -84,6 +84,7 @@ describe('toggle_triptych', function()
           nvim_buf_get_name = {},
           nvim_get_current_win = 0,
           nvim_set_current_win = {},
+          nvim_buf_get_option = {},
         },
         fs = {
           dirname = {},
@@ -110,16 +111,14 @@ describe('toggle_triptych', function()
         nvim_set_current_win = function(winid)
           table.insert(spies.vim.api.nvim_set_current_win, winid)
         end,
+        nvim_buf_get_option = function(bufid, option_name)
+          table.insert(spies.vim.api.nvim_buf_get_option, { bufid, option_name })
+        end,
       },
       fs = {
         dirname = function(path)
           table.insert(spies.vim.fs.dirname, path)
           return vim.fs.dirname(path)
-        end,
-      },
-      fn = {
-        getcwd = function()
-          spies.vim.fn.getcwd = spies.vim.fn.getcwd + 1
         end,
       },
     }
@@ -183,8 +182,8 @@ describe('toggle_triptych', function()
     assert.same(1, spies.git.new)
     assert.same(1, spies.diagnostics.new)
     assert.same({ 100 }, spies.file_reader.new)
+    assert.same({ { 0, 'buftype' } }, spies.vim.api.nvim_buf_get_option)
     assert.same({ 0 }, spies.vim.api.nvim_buf_get_name)
-    assert.same(1, spies.vim.fn.getcwd)
     assert.same({ '/hello/world' }, spies.vim.fs.dirname)
     assert.same(1, spies.float.create_three_floating_windows)
     assert.same({
@@ -235,6 +234,7 @@ describe('toggle_triptych', function()
         nvim_set_current_win = function(winid)
           table.insert(spies.nvim_set_current_win, winid)
         end,
+        nvim_buf_get_option = function(_, _) end,
       },
       fs = {
         dirname = function(path)


### PR DESCRIPTION
* Update init.lua

fixed issue when invoking `:Triptych` from a terminal window

* can now spawn from a file buffer and from a terminal buffer

* cleanup

* using an explicity dir value for tests ?

* cleanup

* Update lua/triptych/init.lua



* Update lua/triptych/init.lua



* Update lua/triptych/init.lua



* Update lua/triptych/init.lua



---------