### PR TITLE
fix behaviour when opening from a non-file buffer

### DIFF
--- a/lua/triptych/init.lua
+++ b/lua/triptych/init.lua
@@ -42,8 +42,11 @@ local function toggle_triptych(dir)
       return vim.fn.getcwd()
     else
       -- otherwise open the directory containing the current file and select it
-      local path = vim.api.nvim_buf_get_name(0)
-      return vim.fs.dirname(path)
+      local bufname = vim.api.nvim_buf_get_name(0)
+      if vim.fn.filereadable(bufname) == 1 then
+        return vim.fs.dirname(bufname)
+      end
+      return vim.fn.getcwd()
     end
   end)
 

--- a/unit_tests/init_spec.lua
+++ b/unit_tests/init_spec.lua
@@ -87,7 +87,7 @@ describe('toggle_triptych', function()
         },
         fn = {
           getcwd = 0,
-          filereadable = {}
+          filereadable = {},
         },
       },
     }
@@ -119,11 +119,11 @@ describe('toggle_triptych', function()
         end,
       },
       fn = {
-        filereadable = function (path)
+        filereadable = function(path)
           table.insert(spies.vim.fn.filereadable, path)
           return 1
-        end
-      }
+        end,
+      },
     }
 
     local mock_state = {
@@ -242,9 +242,9 @@ describe('toggle_triptych', function()
         getcwd = function()
           return '/hello'
         end,
-        filereadable = function ()
+        filereadable = function()
           return 1
-        end
+        end,
       },
     }
 

--- a/unit_tests/init_spec.lua
+++ b/unit_tests/init_spec.lua
@@ -87,6 +87,7 @@ describe('toggle_triptych', function()
         },
         fn = {
           getcwd = 0,
+          filereadable = {}
         },
       },
     }
@@ -117,6 +118,12 @@ describe('toggle_triptych', function()
           return vim.fs.dirname(path)
         end,
       },
+      fn = {
+        filereadable = function (path)
+          table.insert(spies.vim.fn.filereadable, path)
+          return 1
+        end
+      }
     }
 
     local mock_state = {
@@ -174,6 +181,7 @@ describe('toggle_triptych', function()
     assert.same(1, spies.diagnostics.new)
     assert.same({ { 0, 'buftype' } }, spies.vim.api.nvim_buf_get_option)
     assert.same({ 0 }, spies.vim.api.nvim_buf_get_name)
+    assert.same({ '/hello/world' }, spies.vim.fn.filereadable)
     assert.same({ '/hello/world' }, spies.vim.fs.dirname)
     assert.same(1, spies.float.create_three_floating_windows)
     assert.same({
@@ -234,6 +242,9 @@ describe('toggle_triptych', function()
         getcwd = function()
           return '/hello'
         end,
+        filereadable = function ()
+          return 1
+        end
       },
     }
 


### PR DESCRIPTION
Fix bug whereby opening Triptych from a non-file buffer causes strange behaviour. Fallback to cwd if the opening buffer is not a file