### PR TITLE
perf: reduce main thread blocking when reading directories

### DIFF
--- a/lua/triptych/event_handlers.lua
+++ b/lua/triptych/event_handlers.lua
@@ -17,13 +17,13 @@ function M.handle_cursor_moved(State)
   local line_number = vim.api.nvim_win_get_cursor(0)[1]
   State.path_to_line_map[current_dir] = line_number
   if target then
-    local final_target
     if State.collapse_dirs and target.is_dir and target.collapse_path then
-      final_target = fs.read_path(target.collapse_path, true)
+      fs.read_path(target.collapse_path, true, function(final_target)
+        view.set_child_window_target(State, final_target)
+      end)
     else
-      final_target = target
+      view.set_child_window_target(State, target)
     end
-    view.set_child_window_target(State, final_target)
   end
 end
 

--- a/lua/triptych/fs.lua
+++ b/lua/triptych/fs.lua
@@ -66,75 +66,71 @@ local function read_collapsed_dirs(path, display_name)
   return read_collapsed_dirs(path .. '/' .. first_node_name, display_name .. first_node_name .. '/')
 end
 
----@param _path string
+---@param path string
 ---@param include_collapsed boolean whether to drill recursively into collapsed dirs
-function M.read_path(_path, include_collapsed)
-  local path = vim.fs.normalize(_path)
+---@param callback function(tree) end
+function M.read_path(path, include_collapsed, callback)
+  local path_normalized = vim.fs.normalize(path)
 
   local tree = {
-    path = path,
-    display_name = vim.fs.basename(path),
-    dirname = vim.fs.dirname(path), -- i.e. parent dir
-    is_dir = vim.fn.isdirectory(path) == 1,
+    path = path_normalized,
+    display_name = vim.fs.basename(path_normalized),
+    dirname = vim.fs.dirname(path_normalized),
+    is_dir = vim.fn.isdirectory(path_normalized) == 1,
     filetype = nil,
     children = {},
   }
 
-  local handle, _ = vim.loop.fs_scandir(path)
+  local handle = vim.loop.fs_scandir(path_normalized)
   if not handle then
-    -- On error fallback to cwd
-    return M.read_path(vim.fn.getcwd())
+    -- Fallback to cwd asynchronously
+    return M.read_path(vim.fn.getcwd(), include_collapsed, callback)
   end
 
-  while true do
-    local name, type = vim.loop.fs_scandir_next(handle)
-    if not name then
-      break
+  local function process_entries()
+    local name, entry_type = vim.loop.fs_scandir_next(handle)
+    if name then
+      local entry_path = path_normalized .. '/' .. name
+      local is_dir = entry_type == 'directory' or (entry_type == 'link' and vim.fn.isdirectory(entry_path) == 1)
+      local display_name = is_dir and (name .. '/') or name
+
+      local entry = {
+        display_name = display_name,
+        path = entry_path,
+        dirname = path_normalized,
+        is_dir = is_dir,
+        filetype = nil,
+        children = {},
+      }
+
+      if not is_dir then
+        entry.filetype = M.get_filetype_from_path(entry_path)
+      elseif include_collapsed then
+        local collapsed_path, collapsed_display_name = read_collapsed_dirs(entry_path, display_name)
+        entry.collapse_path = collapsed_path
+        entry.collapse_display_name = collapsed_display_name
+      end
+
+      table.insert(tree.children, entry)
+      -- Schedule next iteration to yield to the event loop
+      vim.schedule(process_entries)
+    else
+      if vim.g.triptych_config.options.dirs_first then
+        table.sort(tree.children, function(a, b)
+          if a.is_dir and not b.is_dir then
+            return true
+          elseif not a.is_dir and b.is_dir then
+            return false
+          else
+            return a.path < b.path
+          end
+        end)
+      end
+      callback(tree)
     end
-    local entry_path = path .. '/' .. name
-    local is_dir = u.eval(function()
-      if type == 'directory' then
-        return true
-      elseif type == 'link' then
-        return vim.fn.isdirectory(entry_path) == 1
-      end
-      return false
-    end)
-    local display_name = is_dir and (name .. '/') or name
-    local entry = {
-      display_name = display_name,
-      path = entry_path,
-      dirname = path,
-      is_dir = is_dir,
-      filetype = u.eval(function()
-        if is_dir then
-          return
-        end
-        return M.get_filetype_from_path(entry_path)
-      end),
-      children = {},
-    }
-    if is_dir and include_collapsed then
-      local collapsed_path, collapsed_display_name = read_collapsed_dirs(entry_path, display_name)
-      entry.collapse_path = collapsed_path
-      entry.collapse_display_name = collapsed_display_name
-    end
-    table.insert(tree.children, entry)
   end
 
-  if vim.g.triptych_config.options.dirs_first then
-    table.sort(tree.children, function(a, b)
-      if a.is_dir and not b.is_dir then
-        return true
-      end
-      if not a.is_dir and b.is_dir then
-        return false
-      end
-      return a.path < b.path
-    end)
-  end
-
-  return tree
+  process_entries()
 end
 
 return M

--- a/lua/triptych/view.lua
+++ b/lua/triptych/view.lua
@@ -45,8 +45,9 @@ end
 ---@param win_type WinType
 ---@param maybe_cursor_target_path string?
 local function read_path_and_publish(path, win_type, maybe_cursor_target_path)
-  local path_details = fs.read_path(path, win_type ~= 'parent')
-  autocmds.send_path_read(path_details, win_type, maybe_cursor_target_path)
+  fs.read_path(path, win_type ~= 'parent', function(path_details)
+    autocmds.send_path_read(path_details, win_type, maybe_cursor_target_path)
+  end)
 end
 
 ---Read a file, then publish the results to a User event


### PR DESCRIPTION
When scanning a directory, yield control of the main thread between each entry. Very large files could still create lag though.