### PR TITLE
feat: update winborder to prefer vim.o.winborder if available

### DIFF
--- a/lua/triptych/config.lua
+++ b/lua/triptych/config.lua
@@ -149,7 +149,7 @@ local function default_config()
       },
       backdrop = 60,
       transparency = 0,
-      border = 'single',
+      border = (vim.fn.exists('+winborder') == 1 and vim.o.winborder ~= '') and vim.o.winborder or 'single',
       max_height = 45,
       max_width = 220,
       margin_x = 4,


### PR DESCRIPTION
- By default use vim.o.winborder if available, otherwise keep default "single"